### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,274 +1,54 @@
 # fp
 
-  - [Macros](#macros)
-      - [fp--pipe (\&rest functions)](#fp--pipe-rest-functions)
-      - [fp--compose (\&rest functions)](#fp--compose-rest-functions)
-      - [fp--partial (fn \&rest args)](#fp--partial-fn-rest-args)
-      - [fp--rpartial (fn \&rest args)](#fp--rpartial-fn-rest-args)
-      - [fp--and (\&rest functions)](#fp--and-rest-functions)
-      - [fp--or (\&rest functions)](#fp--or-rest-functions)
-      - [fp--converge (combine-fn \&rest
-        functions)](#fp--converge-combine-fn-rest-functions)
-      - [fp--when (pred fn)](#fp--when-pred-fn)
-      - [fp--unless (pred fn)](#fp--unless-pred-fn)
-      - [fp--const (value)](#fp--const-value)
-      - [fp--ignore-args (fn)](#fp--ignore-args-fn)
-  - [Functions](#functions)
+  - [Requirements](#requirements)
+  - [Installation](#installation)
+      - [Manually](#manually)
+      - [With use-package and straight](#with-use-package-and-straight)
+  - [Usage](#usage)
       - [fp-pipe (\&rest functions)](#fp-pipe-rest-functions)
       - [fp-compose (\&rest functions)](#fp-compose-rest-functions)
       - [fp-partial (fn \&rest args)](#fp-partial-fn-rest-args)
       - [fp-rpartial (fn \&rest args)](#fp-rpartial-fn-rest-args)
+      - [fp-and (\&rest functions)](#fp-and-rest-functions)
+      - [fp-or (\&rest functions)](#fp-or-rest-functions)
+      - [fp-converge (combine-fn \&rest
+        functions)](#fp-converge-combine-fn-rest-functions)
+      - [fp-when (pred fn)](#fp-when-pred-fn)
+      - [fp-unless (pred fn)](#fp-unless-pred-fn)
+      - [fp-const (value)](#fp-const-value)
+      - [fp-ignore-args (fn)](#fp-ignore-args-fn)
 
-## Macros
+## Requirements
 
-### fp--pipe (\&rest functions)
+  - Emacs \>= 25.1
 
-Return left-to-right composition from `functions`.
+## Installation
 
-**Example:**
+### Manually
 
-``` elisp
-(funcall (fp--pipe upcase split-string) "some string")
-```
-
-**Result:**
-
-``` elisp
-("SOME" "STRING")
-```
-
-### fp--compose (\&rest functions)
-
-Return right-to-left composition from `functions`.
-
-**Example:**
+Download repository and it to your load path in your init file:
 
 ``` elisp
-(funcall (fp--compose split-string upcase) "some string")
+
+(add-to-list 'load-path "/path/to/fp)
+
+(require 'fp)
+
 ```
 
-**Result:**
+### With use-package and straight
 
 ``` elisp
-("SOME" "STRING")
+
+(use-package fp
+    :straight (fp
+                   :repo "KarimAziev/fp"
+                   :type git
+                   :host github))
+
 ```
 
-### fp--partial (fn \&rest args)
-
-Return a partial application of `fn` to left-hand `args`.
-
-`args` is a list of the last N arguments to pass to `fn`. The result is
-a new function which does the same as `fn`, except that the last N
-arguments are fixed at the values with which this function was called.
-
-**Example:**
-
-``` elisp
-(funcall (fp--partial > 3) 2)
-```
-
-**Result:**
-
-``` elisp
-t
-```
-
-### fp--rpartial (fn \&rest args)
-
-Return a partial application of `fn` to right-hand `args`.
-
-`args` is a list of the last N arguments to pass to `fn`. The result is
-a new function which does the same as `fn`, except that the last N
-arguments are fixed at the values with which this function was called.
-
-**Example:**
-
-``` elisp
-(funcall (fp--rpartial > 3) 2)
-```
-
-**Result:**
-
-``` elisp
-nil
-```
-
-**Example:**
-
-``` elisp
-(funcall (fp--rpartial plist-get :name) '(:name "John" :age 30))
-```
-
-**Result:**
-
-``` elisp
-"John"
-```
-
-### fp--and (\&rest functions)
-
-Return an unary function which call invoke `functions` until one of them
-yields nil.
-
-**Example:**
-
-``` elisp
-(funcall (fp--and numberp 1+) 30)
-```
-
-**Result:**
-
-``` elisp
-31
-```
-
-### fp--or (\&rest functions)
-
-Return a function that `functions` until one of them yields non-nil.
-
-**Example:**
-
-``` elisp
-(seq-filter
- (fp--or numberp stringp)
- '("a" "b" (0 1 2 3 4) "c" 34 (:name "John" :age 30)))
-```
-
-**Result:**
-
-``` elisp
-("a" "b" "c" 34)
-```
-
-### fp--converge (combine-fn \&rest functions)
-
-Return a new function that accepts a converging function COMBINE-FN and
-a list of branching `functions`.
-
-When invoked, this new function is applied to some arguments, and each
-branching function is applied to those same arguments. The results of
-each branching function are passed as arguments to the converging
-function to produce the return value.
-
-If first element of `functions` is a vector, it will be used instead.
-
-For example here both `upcase` and `downcase` applied with argument
-John, and `concat` applied with results.
-
-**Example:**
-
-``` elisp
-(funcall (fp--converge concat [upcase downcase]) "John")
-```
-
-**Result:**
-
-``` elisp
-"JOHNjohn"
-```
-
-**Example:**
-
-``` elisp
-(funcall (fp--converge concat upcase downcase) "John")
-```
-
-**Result:**
-
-``` elisp
-"JOHNjohn"
-```
-
-### fp--when (pred fn)
-
-Return an unary function that invoke `fn` if result of calling PRED is
-non-nil.
-
-If result of PRED is nil, return the argument as is.
-
-Both PRED and `fn` called with one argument.
-
-``` elisp
-(defun truncate-maybe (str len)
-  "Truncate STR if longer LEN, otherwise return STR."
-  (funcall (fp--when
-            (fp--compose (fp--partial < len) length)
-            (fp--rpartial substring 0 len))
-           str))
-
-(list (truncate-maybe "long string" 4)
-      (truncate-maybe "lo" 4))
-```
-
-**Result:**
-
-``` elisp
-("long" "lo")
-```
-
-### fp--unless (pred fn)
-
-Return an unary function that invoke `fn` if result of calling PRED is
-non-nil.
-
-If result of PRED is nil, return the argument as is.
-
-Both PRED and `fn` called with one argument.
-
-``` elisp
-(defun divide-maybe (a b)
-  "Divide A and B unless B is 0."
-  (funcall (fp--unless zerop
-                       (fp--partial / a))
-           b))
-
-(list (divide-maybe 10 0)
-      (divide-maybe 10 2))
-```
-
-**Result**:
-
-``` elisp
-(0 5)
-```
-
-### fp--const (value)
-
-Return a function that always return `value.`
-
-This function accepts any number of arguments, but ignores them.
-
-``` elisp
-(funcall (fp--const 2) 4)
-```
-
-**Result**:
-
-``` elisp
-2
-```
-
-### fp--ignore-args (fn)
-
-Return a function that invoke `fn` without args.
-
-This function accepts any number of arguments, but ignores them.
-
-``` elisp
-(defun my-fn ()
-  "Show message hello world."
-  (message "Hello world"))
-
-(funcall (fp--ignore-args my-fn) 4)
-```
-
-**Result**:
-
-``` elisp
-"Hello world"
-```
-
-## Functions
+## Usage
 
 ### fp-pipe (\&rest functions)
 
@@ -277,7 +57,7 @@ Return left-to-right composition from `functions`.
 **Example:**
 
 ``` elisp
-(funcall (fp-pipe #'upcase #'split-string) "some string")
+(funcall (fp-pipe upcase split-string) "some string")
 ```
 
 **Result:**
@@ -293,8 +73,7 @@ Return right-to-left composition from `functions`.
 **Example:**
 
 ``` elisp
-(funcall (fp-compose #'split-string #'upcase) "some string")
-
+(funcall (fp-compose split-string upcase) "some string")
 ```
 
 **Result:**
@@ -314,7 +93,7 @@ arguments are fixed at the values with which this function was called.
 **Example:**
 
 ``` elisp
-(funcall (fp-partial #'> 3) 2)
+(funcall (fp-partial > 3) 2)
 ```
 
 **Result:**
@@ -334,11 +113,186 @@ arguments are fixed at the values with which this function was called.
 **Example:**
 
 ``` elisp
-(funcall (fp-rpartial #'> 3) 2)
+(funcall (fp-rpartial > 3) 2)
 ```
 
 **Result:**
 
 ``` elisp
 nil
+```
+
+**Example:**
+
+``` elisp
+(funcall (fp-rpartial plist-get :name) '(:name "John" :age 30))
+```
+
+**Result:**
+
+``` elisp
+"John"
+```
+
+### fp-and (\&rest functions)
+
+Return an unary function which call invoke `functions` until one of them
+yields nil.
+
+**Example:**
+
+``` elisp
+(funcall (fp-and numberp 1+) 30)
+```
+
+**Result:**
+
+``` elisp
+31
+```
+
+### fp-or (\&rest functions)
+
+Return a function that `functions` until one of them yields non-nil.
+
+**Example:**
+
+``` elisp
+(seq-filter
+ (fp-or numberp stringp)
+ '("a" "b" (0 1 2 3 4) "c" 34 (:name "John" :age 30)))
+```
+
+**Result:**
+
+``` elisp
+("a" "b" "c" 34)
+```
+
+### fp-converge (combine-fn \&rest functions)
+
+Return a new function that accepts a converging function COMBINE-FN and
+a list of branching `functions`.
+
+When invoked, this new function is applied to some arguments, and each
+branching function is applied to those same arguments. The results of
+each branching function are passed as arguments to the converging
+function to produce the return value.
+
+If first element of `functions` is a vector, it will be used instead.
+
+For example here both `upcase` and `downcase` applied with argument
+John, and `concat` applied with results.
+
+**Example:**
+
+``` elisp
+(funcall (fp-converge concat [upcase downcase]) "John")
+```
+
+**Result:**
+
+``` elisp
+"JOHNjohn"
+```
+
+**Example:**
+
+``` elisp
+(funcall (fp-converge concat upcase downcase) "John")
+```
+
+**Result:**
+
+``` elisp
+"JOHNjohn"
+```
+
+### fp-when (pred fn)
+
+Return an unary function that invoke `fn` if result of calling PRED is
+non-nil.
+
+If result of PRED is nil, return the argument as is.
+
+Both PRED and `fn` called with one argument.
+
+``` elisp
+(defun truncate-maybe (str len)
+  "Truncate STR if longer LEN, otherwise return STR."
+  (funcall (fp-when
+            (fp-compose (fp-partial < len) length)
+            (fp-rpartial substring 0 len))
+           str))
+
+(list (truncate-maybe "long string" 4)
+      (truncate-maybe "lo" 4))
+```
+
+**Result:**
+
+``` elisp
+("long" "lo")
+```
+
+### fp-unless (pred fn)
+
+Return an unary function that invoke `fn` if result of calling PRED is
+non-nil.
+
+If result of PRED is nil, return the argument as is.
+
+Both PRED and `fn` called with one argument.
+
+``` elisp
+(defun divide-maybe (a b)
+  "Divide A and B unless B is 0."
+  (funcall (fp-unless zerop
+                       (fp-partial / a))
+           b))
+
+(list (divide-maybe 10 0)
+      (divide-maybe 10 2))
+```
+
+**Result**:
+
+``` elisp
+(0 5)
+```
+
+### fp-const (value)
+
+Return a function that always return `value.`
+
+This function accepts any number of arguments, but ignores them.
+
+``` elisp
+(funcall (fp-const 2) 4)
+```
+
+**Result**:
+
+``` elisp
+2
+```
+
+### fp-ignore-args (fn)
+
+Return a function that invoke `fn` without args.
+
+This function accepts any number of arguments, but ignores them.
+
+``` elisp
+(defun my-fn ()
+  "Show message hello world."
+  (message "Hello world"))
+
+(funcall (fp-ignore-args my-fn) 4)
+```
+
+**Result**:
+
+``` elisp
+"Hello world"
 ```

--- a/README.org
+++ b/README.org
@@ -1,33 +1,61 @@
 #+OPTIONS: toc:4 num:nil
 
+
 * fp
-  - [[#macros][Macros]]
-    - [[#fp--pipe-rest-functions][fp--pipe (&rest functions)]]
-    - [[#fp--compose-rest-functions][fp--compose (&rest functions)]]
-    - [[#fp--partial-fn-rest-args][fp--partial (fn &rest args)]]
-    - [[#fp--rpartial-fn-rest-args][fp--rpartial (fn &rest args)]]
-    - [[#fp--and-rest-functions][fp--and (&rest functions)]]
-    - [[#fp--or-rest-functions][fp--or (&rest functions)]]
-    - [[#fp--converge-combine-fn-rest-functions][fp--converge (combine-fn &rest functions)]]
-    - [[#fp--when-pred-fn][fp--when (pred fn)]]
-    - [[#fp--unless-pred-fn][fp--unless (pred fn)]]
-    - [[#fp--const-value][fp--const (value)]]
-    - [[#fp--ignore-args-fn][fp--ignore-args (fn)]]
-  - [[#functions][Functions]]
+  - [[#requirements][Requirements]]
+  - [[#installation][Installation]]
+    - [[#manually][Manually]]
+    - [[#with-use-package-and-straight][With use-package and straight]]
+  - [[#usage][Usage]]
     - [[#fp-pipe-rest-functions][fp-pipe (&rest functions)]]
     - [[#fp-compose-rest-functions][fp-compose (&rest functions)]]
     - [[#fp-partial-fn-rest-args][fp-partial (fn &rest args)]]
     - [[#fp-rpartial-fn-rest-args][fp-rpartial (fn &rest args)]]
+    - [[#fp-and-rest-functions][fp-and (&rest functions)]]
+    - [[#fp-or-rest-functions][fp-or (&rest functions)]]
+    - [[#fp-converge-combine-fn-rest-functions][fp-converge (combine-fn &rest functions)]]
+    - [[#fp-when-pred-fn][fp-when (pred fn)]]
+    - [[#fp-unless-pred-fn][fp-unless (pred fn)]]
+    - [[#fp-const-value][fp-const (value)]]
+    - [[#fp-ignore-args-fn][fp-ignore-args (fn)]]
 
-** Macros
-#+PROPERTY: header-args :results code
-*** fp--pipe (&rest functions)
+** Requirements
+
++ Emacs >= 25.1
+
+** Installation
+
+*** Manually
+
+Download repository and it to your load path in your init file:
+
+#+begin_src elisp :eval no
+
+(add-to-list 'load-path "/path/to/fp)
+
+(require 'fp)
+
+#+end_src
+
+*** With use-package and straight
+
+#+begin_src elisp :eval no
+
+(use-package fp
+	:straight (fp
+			       :repo "KarimAziev/fp"
+			       :type git
+			       :host github))
+
+#+end_src
+** Usage
+*** fp-pipe (&rest functions)
 
 Return left-to-right composition from ~functions~.
 
 *Example:*
 #+begin_src emacs-lisp :results raw :results code
-(funcall (fp--pipe upcase split-string) "some string")
+(funcall (fp-pipe upcase split-string) "some string")
 #+end_src
 
 *Result:*
@@ -35,13 +63,13 @@ Return left-to-right composition from ~functions~.
 ("SOME" "STRING")
 #+end_src
 
-*** fp--compose (&rest functions)
+*** fp-compose (&rest functions)
 
 Return right-to-left composition from ~functions~.
 
 *Example:*
 #+begin_src emacs-lisp
-(funcall (fp--compose split-string upcase) "some string")
+(funcall (fp-compose split-string upcase) "some string")
 #+end_src
 
 *Result:*
@@ -49,16 +77,16 @@ Return right-to-left composition from ~functions~.
 ("SOME" "STRING")
 #+end_src
 
-*** fp--partial (fn &rest args)
-Return a partial application of ~fn~ to left-hand ~args~.
+*** fp-partial (fn &rest args)
+Return a partial application of =fn= to left-hand ~args~.
 
-~args~ is a list of the last N arguments to pass to ~fn~. The result is a new
-function which does the same as ~fn~, except that the last N arguments are fixed
+~args~ is a list of the last N arguments to pass to =fn=. The result is a new
+function which does the same as =fn=, except that the last N arguments are fixed
 at the values with which this function was called.
 
 *Example:*
 #+begin_src elisp
-(funcall (fp--partial > 3) 2)
+(funcall (fp-partial > 3) 2)
 #+end_src
 
 *Result:*
@@ -66,16 +94,16 @@ at the values with which this function was called.
 t
 #+end_src
 
-*** fp--rpartial (fn &rest args)
-Return a partial application of ~fn~ to right-hand ~args~.
+*** fp-rpartial (fn &rest args)
+Return a partial application of =fn= to right-hand ~args~.
 
-~args~ is a list of the last N arguments to pass to ~fn~. The result is a new
-function which does the same as ~fn~, except that the last N arguments are fixed
+~args~ is a list of the last N arguments to pass to =fn=. The result is a new
+function which does the same as =fn=, except that the last N arguments are fixed
 at the values with which this function was called.
 
 *Example:*
 #+begin_src elisp
-(funcall (fp--rpartial > 3) 2)
+(funcall (fp-rpartial > 3) 2)
 #+end_src
 
 *Result:*
@@ -85,7 +113,7 @@ nil
 
 *Example:*
 #+begin_src elisp
-(funcall (fp--rpartial plist-get :name) '(:name "John" :age 30))
+(funcall (fp-rpartial plist-get :name) '(:name "John" :age 30))
 #+end_src
 
 *Result:*
@@ -93,12 +121,12 @@ nil
 "John"
 #+end_src
 
-*** fp--and (&rest functions)
+*** fp-and (&rest functions)
 Return an unary function which call invoke ~functions~ until one of them yields nil.
 
 *Example:*
 #+begin_src elisp
-(funcall (fp--and numberp 1+) 30)
+(funcall (fp-and numberp 1+) 30)
 #+end_src
 
 *Result:*
@@ -106,13 +134,13 @@ Return an unary function which call invoke ~functions~ until one of them yields 
 31
 #+end_src
 
-*** fp--or (&rest functions)
+*** fp-or (&rest functions)
 Return a function that ~functions~ until one of them yields non-nil.
 
 *Example:*
 #+begin_src elisp
 (seq-filter
- (fp--or numberp stringp)
+ (fp-or numberp stringp)
  '("a" "b" (0 1 2 3 4) "c" 34 (:name "John" :age 30)))
 #+end_src
 
@@ -121,7 +149,7 @@ Return a function that ~functions~ until one of them yields non-nil.
 ("a" "b" "c" 34)
 #+end_src
 
-*** fp--converge (combine-fn &rest functions)
+*** fp-converge (combine-fn &rest functions)
 
 Return a new function that accepts a converging function COMBINE-FN and a list of branching ~functions~.
 
@@ -133,7 +161,7 @@ For example here both ~upcase~ and ~downcase~ applied with argument John, and ~c
 
 *Example:*
 #+begin_src emacs-lisp
-(funcall (fp--converge concat [upcase downcase]) "John")
+(funcall (fp-converge concat [upcase downcase]) "John")
 #+end_src
 
 *Result:*
@@ -143,7 +171,7 @@ For example here both ~upcase~ and ~downcase~ applied with argument John, and ~c
 
 *Example:*
 #+begin_src emacs-lisp :results code
-(funcall (fp--converge concat upcase downcase) "John")
+(funcall (fp-converge concat upcase downcase) "John")
 #+end_src
 
 *Result:*
@@ -151,19 +179,19 @@ For example here both ~upcase~ and ~downcase~ applied with argument John, and ~c
 "JOHNjohn"
 #+end_src
 
-*** fp--when (pred fn)
-Return an unary function that invoke ~fn~ if result of calling PRED is non-nil.
+*** fp-when (pred fn)
+Return an unary function that invoke =fn= if result of calling PRED is non-nil.
 
 If result of PRED is nil, return the argument as is.
 
-Both PRED and ~fn~ called with one argument.
+Both PRED and =fn= called with one argument.
 
 #+begin_src emacs-lisp
 (defun truncate-maybe (str len)
   "Truncate STR if longer LEN, otherwise return STR."
-  (funcall (fp--when
-            (fp--compose (fp--partial < len) length)
-            (fp--rpartial substring 0 len))
+  (funcall (fp-when
+            (fp-compose (fp-partial < len) length)
+            (fp-rpartial substring 0 len))
            str))
 
 (list (truncate-maybe "long string" 4)
@@ -175,18 +203,18 @@ Both PRED and ~fn~ called with one argument.
 ("long" "lo")
 #+end_src
 
-*** fp--unless (pred fn)
-Return an unary function that invoke ~fn~ if result of calling PRED is non-nil.
+*** fp-unless (pred fn)
+Return an unary function that invoke =fn= if result of calling PRED is non-nil.
 
 If result of PRED is nil, return the argument as is.
 
-Both PRED and ~fn~ called with one argument.
+Both PRED and =fn= called with one argument.
 
 #+begin_src emacs-lisp
 (defun divide-maybe (a b)
   "Divide A and B unless B is 0."
-  (funcall (fp--unless zerop
-                       (fp--partial / a))
+  (funcall (fp-unless zerop
+                       (fp-partial / a))
            b))
 
 (list (divide-maybe 10 0)
@@ -198,14 +226,14 @@ Both PRED and ~fn~ called with one argument.
 (0 5)
 #+end_src
 
-*** fp--const (value)
+*** fp-const (value)
 
 Return a function that always return ~value.~
 
 This function accepts any number of arguments, but ignores them.
 
 #+begin_src emacs-lisp
-(funcall (fp--const 2) 4)
+(funcall (fp-const 2) 4)
 #+end_src
 
 *Result*:
@@ -213,9 +241,9 @@ This function accepts any number of arguments, but ignores them.
 2
 #+end_src
 
-*** fp--ignore-args (fn)
+*** fp-ignore-args (fn)
 
-Return a function that invoke ~fn~ without args.
+Return a function that invoke =fn= without args.
 
 This function accepts any number of arguments, but ignores them.
 
@@ -224,73 +252,10 @@ This function accepts any number of arguments, but ignores them.
   "Show message hello world."
   (message "Hello world"))
 
-(funcall (fp--ignore-args my-fn) 4)
+(funcall (fp-ignore-args my-fn) 4)
 #+end_src
 
 *Result*:
 #+begin_src emacs-lisp
 "Hello world"
-#+end_src
-
-** Functions
-#+PROPERTY: header-args :results code
-*** fp-pipe (&rest functions)
-Return left-to-right composition from ~functions~.
-
-*Example:*
-#+begin_src emacs-lisp
-(funcall (fp-pipe #'upcase #'split-string) "some string")
-#+end_src
-
-*Result:*
-#+begin_src emacs-lisp
-("SOME" "STRING")
-#+end_src
-
-*** fp-compose (&rest functions)
-Return right-to-left composition from ~functions~.
-
-*Example:*
-#+begin_src emacs-lisp
-(funcall (fp-compose #'split-string #'upcase) "some string")
-
-#+end_src
-
-*Result:*
-#+begin_src emacs-lisp
-("SOME" "STRING")
-#+end_src
-
-*** fp-partial (fn &rest args)
-Return a partial application of ~fn~ to left-hand ~args~.
-
-~args~ is a list of the last N arguments to pass to ~fn~. The result is a new
-function which does the same as ~fn~, except that the last N arguments are fixed
-at the values with which this function was called.
-
-*Example:*
-#+begin_src elisp
-(funcall (fp-partial #'> 3) 2)
-#+end_src
-
-*Result:*
-#+begin_src elisp
-t
-#+end_src
-
-*** fp-rpartial (fn &rest args)
-Return a partial application of ~fn~ to right-hand ~args~.
-
-~args~ is a list of the last N arguments to pass to ~fn~. The result is a new
-function which does the same as ~fn~, except that the last N arguments are fixed
-at the values with which this function was called.
-
-*Example:*
-#+begin_src elisp
-(funcall (fp-rpartial #'> 3) 2)
-#+end_src
-
-*Result:*
-#+begin_src elisp
-nil
 #+end_src

--- a/fp.el
+++ b/fp.el
@@ -5,8 +5,8 @@
 ;; Author: Karim Aziiev <karim.aziiev@gmail.com>
 ;; URL: https://github.com/KarimAziev/fp
 ;; Keywords: lisp
-;; Version: 0.3.0
-;; Package-Requires: ((emacs "27.1"))
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -32,7 +32,7 @@
 ;;; Code:
 
 ;;;###autoload
-(defmacro fp--pipe (&rest functions)
+(defmacro fp-pipe (&rest functions)
   "Return left-to-right composition from FUNCTIONS."
   (declare (debug t) (pure t) (side-effect-free t))
   `(lambda (&rest args)
@@ -49,13 +49,13 @@
              `(apply ,init-fn args)))))))
 
 ;;;###autoload
-(defmacro fp--compose (&rest functions)
+(defmacro fp-compose (&rest functions)
   "Return right-to-left composition from FUNCTIONS."
   (declare (debug t) (pure t) (side-effect-free t))
-  `(fp--pipe ,@(reverse functions)))
+  `(fp-pipe ,@(reverse functions)))
 
 ;;;###autoload
-(defmacro fp--or (&rest functions)
+(defmacro fp-or (&rest functions)
   "Return an unary function which invoke FUNCTIONS until first non-nil result."
   (declare (debug t) (pure t) (side-effect-free t))
   `(lambda (it) (or
@@ -65,7 +65,7 @@
                       functions))))
 
 ;;;###autoload
-(defmacro fp--and (&rest functions)
+(defmacro fp-and (&rest functions)
   "Return an unary function which invoke FUNCTIONS until first nil result."
   (declare (debug t) (pure t) (side-effect-free t))
   `(lambda (it) (and
@@ -75,7 +75,7 @@
                       functions))))
 
 ;;;###autoload
-(defmacro fp--partial (fn &rest args)
+(defmacro fp-partial (fn &rest args)
   "Return a partial application of FN to left-hand ARGS.
 
 ARGS is a list of the last N arguments to pass to FN. The result is a new
@@ -88,7 +88,7 @@ at the values with which this function was called."
                    `(apply ,fn (append (list ,@args) pre-args)))))))
 
 ;;;###autoload
-(defmacro fp--rpartial (fn &rest args)
+(defmacro fp-rpartial (fn &rest args)
   "Return a partial application of FN to right-hand ARGS.
 
 ARGS is a list of the last N arguments to pass to FN. The result is a new
@@ -101,14 +101,14 @@ at the values with which this function was called."
                    `(apply ,fn (append pre-args (list ,@args))))))))
 
 ;;;###autoload
-(defmacro fp--converge (combine-fn &rest functions)
+(defmacro fp-converge (combine-fn &rest functions)
   "Return a function that apply COMBINE-FN with results of branching FUNCTIONS.
 If first element of FUNCTIONS is vector, it will be used instead.
 
 Example:
 
-\(funcall (fp--converge concat [upcase downcase]) \"John\").
-\(funcall (fp--converge concat upcase downcase) \"John\")
+\(funcall (fp-converge concat [upcase downcase]) \"John\").
+\(funcall (fp-converge concat upcase downcase) \"John\")
 
 Result: \"JOHNjohn\"."
   `(lambda (&rest args) (apply
@@ -126,7 +126,7 @@ Result: \"JOHNjohn\"."
                                  functions))))))
 
 ;;;###autoload
-(defmacro fp--when (pred fn)
+(defmacro fp-when (pred fn)
   "Return an unary function that invoke FN if result of calling PRED is non-nil.
 Both PRED and FN called with one argument.
 If result of PRED is nil, return the argument as is."
@@ -139,7 +139,7 @@ If result of PRED is nil, return the argument as is."
               arg)))
 
 ;;;###autoload
-(defmacro fp--unless (pred fn)
+(defmacro fp-unless (pred fn)
   "Return an unary function that invoke FN if result of calling PRED is nil.
 Both PRED and FN called with one argument.
 If result of PRED is non nil return the argument as is."
@@ -152,7 +152,7 @@ If result of PRED is non nil return the argument as is."
                  `(funcall ,fn arg)))))
 
 ;;;###autoload
-(defmacro fp--const (value)
+(defmacro fp-const (value)
   "Return a function that always return VALUE.
 
 This function accepts any number of arguments, but ignores them."
@@ -160,63 +160,13 @@ This function accepts any number of arguments, but ignores them."
   `(lambda (&rest _) ,value))
 
 ;;;###autoload
-(defmacro fp--ignore-args (fn)
+(defmacro fp-ignore-args (fn)
   "Return a function that invoke FN without args.
 
 This function accepts any number of arguments, but ignores them."
   `(lambda (&rest _) ,(if (symbolp fn)
                      `(,fn)
                    `(funcall ,fn arg))))
-
-;;;###autoload
-(defun fp-partial (fn &rest args)
-  "Return a function that is a partial application of FN to ARGS.
-
-ARGS is a list of the first N arguments to pass to FN.
-The result is a new function which does the same as FN, except that
-the first N arguments are fixed at the values with which this function
-was called."
-  (lambda (&rest args2)
-    (apply fn (append args args2))))
-
-;;;###autoload
-(defun fp-rpartial (fn &rest args)
-  "Return a partial application of FN to right-hand ARGS.
-
-ARGS is a list of the last N arguments to pass to FN. The result is a new
-function which does the same as FN, except that the last N arguments are fixed
-at the values with which this function was called."
-  (lambda (&rest pre-args)
-    (apply fn (append pre-args args))))
-
-;;;###autoload
-(defun fp-compose (&rest functions)
-  "Return right-to-left composition from FUNCTIONS."
-  (lambda (&rest args)
-    (car (seq-reduce (lambda (xs fn) (list (apply fn xs)))
-                     (reverse functions) args))))
-
-;;;###autoload
-(defun fp-pipe (&rest functions)
-  "Return right-to-left composition from FUNCTIONS."
-  (lambda (&rest args)
-    (car (seq-reduce (lambda (xs fn) (list (apply fn xs)))
-                     functions args))))
-
-;;;###autoload
-(defun fp-compose-while-not-nil (&rest functions)
-  "Return right-to-left composition from FUNCTIONS."
-  (let ((fn))
-    (setq functions (reverse functions))
-    (setq fn (pop functions))
-    (lambda (&rest args)
-      (let ((arg (unless (null (flatten-list args))
-                   (apply fn args))))
-        (while (setq fn (unless (null arg)
-                          (pop functions)))
-          (let ((res (apply fn (list arg))))
-            (setq arg res)))
-        arg))))
 
 (provide 'fp)
 ;;; fp.el ends here


### PR DESCRIPTION
- remove all plain functions in favor of macros
- change prefix in macros due to Emacs lisp conventions: from `fp--` to `fp-`